### PR TITLE
Added rule flushing on save

### DIFF
--- a/controllers/Redirects.php
+++ b/controllers/Redirects.php
@@ -143,10 +143,9 @@ final class Redirects extends Controller
      */
     public function update_onSave(?string $context = null)
     {
-        /** @noinspection PhpPossiblePolymorphicInvocationInspection */
-        parent::update_onSave($context);
+        $this->asExtension('FormController')->update_onSave($context);
 
-        $fromUrl = post('Redirect')['from_url'] ?? null;
+        $fromUrl = $this->formGetWidget()->getSaveData()['from_url'] ?? null;
 
         if (!$fromUrl) {
             return;


### PR DESCRIPTION
Added an `update_onSave` method to force the rule to be flushed from cache on save. This ensures that after a rule is changed it's effect is immediate.