### PR TITLE
Try matching regex named groups to cms page params.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -8,7 +8,7 @@ This plugins ships with two types of redirects:
 
 * **Exact**; performs an exact match on the Source path.
 * **Placeholders**; matches placeholders like {id} or {category} (like the defined routes in Symfony or Laravel framework).
-* **Regular expression**; Use regular expressions to match multiple patterns at once (advanced).
+* **Regular expression**; Use regular expressions to match multiple patterns at once (advanced). If the regex contains named groups, groups will get matched to cms page params.
 
 ## Redirect target types
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -37,6 +37,8 @@ final class Plugin extends PluginBase
      */
     public function boot(): void
     {
+        $this->registerCustomValidators();
+
         if ($this->app->runningInConsole() || $this->app->runningUnitTests()) {
             return;
         }
@@ -357,6 +359,19 @@ final class Plugin extends PluginBase
             } catch (Throwable $throwable) {
                 // @ignoreException
             }
+        });
+    }
+
+    private function registerCustomValidators(): void
+    {
+        Validator::extend('is_regex', static function ($attribute, $value): bool {
+            try {
+                preg_match($value, '');
+            } catch (Throwable $throwable) {
+                return false;
+            }
+
+            return true;
         });
     }
 }

--- a/Plugin.php
+++ b/Plugin.php
@@ -37,11 +37,12 @@ final class Plugin extends PluginBase
      */
     public function boot(): void
     {
+        $this->registerCustomValidators();
+
         if ($this->app->runningInConsole() || $this->app->runningUnitTests()) {
             return;
         }
 
-        $this->registerCustomValidators();
         $this->registerObservers();
 
         if (!$this->app->runningInBackend()) {

--- a/Plugin.php
+++ b/Plugin.php
@@ -37,12 +37,11 @@ final class Plugin extends PluginBase
      */
     public function boot(): void
     {
-        $this->registerCustomValidators();
-
         if ($this->app->runningInConsole() || $this->app->runningUnitTests()) {
             return;
         }
 
+        $this->registerCustomValidators();
         $this->registerObservers();
 
         if (!$this->app->runningInBackend()) {

--- a/Plugin.php
+++ b/Plugin.php
@@ -301,6 +301,19 @@ final class Plugin extends PluginBase
         $this->registerConsoleCommand('winter.redirect.publish-redirects', PublishRedirectsCommand::class);
     }
 
+    private function registerCustomValidators(): void
+    {
+        Validator::extend('is_regex', static function ($attribute, $value): bool {
+            try {
+                preg_match($value, '');
+            } catch (Throwable $throwable) {
+                return false;
+            }
+
+            return true;
+        });
+    }
+
     private function registerObservers(): void
     {
         Models\Redirect::observe(Observers\RedirectObserver::class);
@@ -359,19 +372,6 @@ final class Plugin extends PluginBase
             } catch (Throwable $throwable) {
                 // @ignoreException
             }
-        });
-    }
-
-    private function registerCustomValidators(): void
-    {
-        Validator::extend('is_regex', static function ($attribute, $value): bool {
-            try {
-                preg_match($value, '');
-            } catch (Throwable $throwable) {
-                return false;
-            }
-
-            return true;
         });
     }
 }

--- a/Plugin.php
+++ b/Plugin.php
@@ -53,8 +53,6 @@ final class Plugin extends PluginBase
     {
         $this->app->register(ServiceProvider::class);
 
-        $this->registerCustomValidators();
-
         $this->registerConsoleCommands();
         $this->registerEventListeners();
     }
@@ -299,19 +297,6 @@ final class Plugin extends PluginBase
     private function registerConsoleCommands(): void
     {
         $this->registerConsoleCommand('winter.redirect.publish-redirects', PublishRedirectsCommand::class);
-    }
-
-    private function registerCustomValidators(): void
-    {
-        Validator::extend('is_regex', static function ($attribute, $value): bool {
-            try {
-                preg_match($value, '');
-            } catch (Throwable $throwable) {
-                return false;
-            }
-
-            return true;
-        });
     }
 
     private function registerObservers(): void

--- a/Plugin.php
+++ b/Plugin.php
@@ -37,8 +37,6 @@ final class Plugin extends PluginBase
      */
     public function boot(): void
     {
-        $this->registerCustomValidators();
-
         if ($this->app->runningInConsole() || $this->app->runningUnitTests()) {
             return;
         }
@@ -54,6 +52,8 @@ final class Plugin extends PluginBase
     public function register(): void
     {
         $this->app->register(ServiceProvider::class);
+
+        $this->registerCustomValidators();
 
         $this->registerConsoleCommands();
         $this->registerEventListeners();

--- a/classes/RedirectManager.php
+++ b/classes/RedirectManager.php
@@ -328,9 +328,17 @@ final class RedirectManager implements RedirectManagerInterface
     {
         $parameters = [];
 
-        // Strip curly braces from keys
-        foreach ($rule->getPlaceholderMatches() as $placeholder => $value) {
-            $parameters[str_replace(['{', '}'], '', (string) $placeholder)] = $value;
+        if ($rule->isRegexMatchType()) {
+            // Try matching named regex groups to cms page params
+            $pregMatchMatches = $rule->getPregMatchMatches();
+            foreach ($pregMatchMatches as $placeholder => $value) {
+                $parameters[(string) $placeholder] = str_replace('/', '', $value);
+            }
+        } else if ($rule->isPlaceholdersMatchType()) {
+            // Strip curly braces from keys
+            foreach ($rule->getPlaceholderMatches() as $placeholder => $value) {
+                $parameters[str_replace(['{', '}'], '', (string) $placeholder)] = $value;
+            }
         }
 
         if ($this->settings->isRelativePathsEnabled()) {

--- a/classes/RedirectManager.php
+++ b/classes/RedirectManager.php
@@ -332,7 +332,7 @@ final class RedirectManager implements RedirectManagerInterface
             // Try matching named regex groups to cms page params
             $pregMatchMatches = $rule->getPregMatchMatches();
             foreach ($pregMatchMatches as $placeholder => $value) {
-                $parameters[(string) $placeholder] = str_replace('/', '', $value);
+                $parameters[(string) $placeholder] = ltrim($value, '/');
             }
         } else if ($rule->isPlaceholdersMatchType()) {
             // Strip curly braces from keys

--- a/classes/RedirectManager.php
+++ b/classes/RedirectManager.php
@@ -334,7 +334,7 @@ final class RedirectManager implements RedirectManagerInterface
             foreach ($pregMatchMatches as $placeholder => $value) {
                 $parameters[(string) $placeholder] = ltrim($value, '/');
             }
-        } else if ($rule->isPlaceholdersMatchType()) {
+        } elseif ($rule->isPlaceholdersMatchType()) {
             // Strip curly braces from keys
             foreach ($rule->getPlaceholderMatches() as $placeholder => $value) {
                 $parameters[str_replace(['{', '}'], '', (string) $placeholder)] = $value;

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,10 @@
             "tests",
             "phpunit.xml"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": false
+        }
     }
 }

--- a/models/Redirect.php
+++ b/models/Redirect.php
@@ -320,23 +320,6 @@ final class Redirect extends Model
     }
 
     /**
-     * Triggered before the model is validated.
-     * Add "is_regex" custom validator
-     */
-    public function beforeValidate(): void
-    {
-        \Validator::extend('is_regex', static function ($attribute, $value): bool {
-            try {
-                preg_match($value, '');
-            } catch (Throwable $throwable) {
-                return false;
-            }
-
-            return true;
-        });
-    }
-
-    /**
      * Triggered before the model is saved, either created or updated.
      * Make sure target fields are correctly set after saving.
      *

--- a/models/Redirect.php
+++ b/models/Redirect.php
@@ -323,7 +323,7 @@ final class Redirect extends Model
      * Triggered before the model is validated.
      * Add "is_regex" custom validator
      */
-    public function beforeValidate(): bool
+    public function beforeValidate(): void
     {
         \Validator::extend('is_regex', static function ($attribute, $value): bool {
             try {

--- a/models/Redirect.php
+++ b/models/Redirect.php
@@ -8,15 +8,15 @@ use Carbon\Carbon;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Fluent;
-use Illuminate\Validation\Validator;
 use System\Models\RequestLog;
 use Winter\Redirect\Classes\OptionHelper;
-use Winter\Storm\Support\Arr;
 use Winter\Storm\Database\Builder;
 use Winter\Storm\Database\Model;
 use Winter\Storm\Database\Relations\HasMany;
 use Winter\Storm\Database\Traits\Sortable;
 use Winter\Storm\Database\Traits\Validation;
+use Winter\Storm\Support\Arr;
+use Winter\Storm\Validation\Validator;
 
 /**
  * @method static Redirect|Builder enabled()
@@ -176,9 +176,11 @@ final class Redirect extends Model
                 && $request->get('target_type') === self::TARGET_TYPE_STATIC_PAGE;
         });
 
-        $validator->sometimes('from_url', 'is_regex', static function (Fluent $request): bool {
-            return $request->get('match_type') === self::TYPE_REGEX;
-        });
+        if (method_exists($validator, 'validateIsRegex')) {
+            $validator->sometimes('from_url', 'is_regex', static function (Fluent $request): bool {
+                return $request->get('match_type') === self::TYPE_REGEX;
+            });
+        }
 
         return $validator;
     }

--- a/models/Redirect.php
+++ b/models/Redirect.php
@@ -176,11 +176,9 @@ final class Redirect extends Model
                 && $request->get('target_type') === self::TARGET_TYPE_STATIC_PAGE;
         });
 
-        if (method_exists($validator, 'validateIsRegex')) {
-            $validator->sometimes('from_url', 'is_regex', static function (Fluent $request): bool {
-                return $request->get('match_type') === self::TYPE_REGEX;
-            });
-        }
+        $validator->sometimes('from_url', 'is_regex', static function (Fluent $request): bool {
+            return $request->get('match_type') === self::TYPE_REGEX;
+        });
 
         return $validator;
     }

--- a/models/Redirect.php
+++ b/models/Redirect.php
@@ -8,16 +8,15 @@ use Carbon\Carbon;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Fluent;
+use Illuminate\Validation\Validator;
 use System\Models\RequestLog;
-use Throwable;
 use Winter\Redirect\Classes\OptionHelper;
+use Winter\Storm\Support\Arr;
 use Winter\Storm\Database\Builder;
 use Winter\Storm\Database\Model;
 use Winter\Storm\Database\Relations\HasMany;
 use Winter\Storm\Database\Traits\Sortable;
 use Winter\Storm\Database\Traits\Validation;
-use Winter\Storm\Support\Arr;
-use Winter\Storm\Validation\Validator;
 
 /**
  * @method static Redirect|Builder enabled()

--- a/models/Redirect.php
+++ b/models/Redirect.php
@@ -9,6 +9,7 @@ use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Fluent;
 use System\Models\RequestLog;
+use Throwable;
 use Winter\Redirect\Classes\OptionHelper;
 use Winter\Storm\Database\Builder;
 use Winter\Storm\Database\Model;
@@ -316,6 +317,23 @@ final class Redirect extends Model
         }
 
         return $options;
+    }
+
+    /**
+     * Triggered before the model is validated.
+     * Add "is_regex" custom validator
+     */
+    public function beforeValidate(): bool
+    {
+        \Validator::extend('is_regex', static function ($attribute, $value): bool {
+            try {
+                preg_match($value, '');
+            } catch (Throwable $throwable) {
+                return false;
+            }
+
+            return true;
+        });
     }
 
     /**

--- a/tests/cases/RedirectManagerTest.php
+++ b/tests/cases/RedirectManagerTest.php
@@ -866,6 +866,8 @@ class RedirectManagerTest extends \Winter\Redirect\Tests\RedirectPluginTestCase
             'to_date' => null,
         ]);
 
+        self::assertTrue($redirect->save());
+
         $rule = RedirectRule::createWithModel($redirect);
         $manager = RedirectManager::createWithRule($rule);
 

--- a/tests/cases/RedirectManagerTest.php
+++ b/tests/cases/RedirectManagerTest.php
@@ -452,6 +452,8 @@ class RedirectManagerTest extends \Winter\Redirect\Tests\RedirectPluginTestCase
             'to_date' => Carbon::today()->addWeek(),
         ]);
 
+        self::assertTrue($redirect->save());
+
         $rule = RedirectRule::createWithModel($redirect);
         $manager = RedirectManager::createWithRule($rule);
 

--- a/tests/cases/RedirectManagerTest.php
+++ b/tests/cases/RedirectManagerTest.php
@@ -452,8 +452,6 @@ class RedirectManagerTest extends \Winter\Redirect\Tests\RedirectPluginTestCase
             'to_date' => Carbon::today()->addWeek(),
         ]);
 
-        self::assertTrue($redirect->save());
-
         $rule = RedirectRule::createWithModel($redirect);
         $manager = RedirectManager::createWithRule($rule);
 
@@ -865,8 +863,6 @@ class RedirectManagerTest extends \Winter\Redirect\Tests\RedirectPluginTestCase
             'from_date' => null,
             'to_date' => null,
         ]);
-
-        self::assertTrue($redirect->save());
 
         $rule = RedirectRule::createWithModel($redirect);
         $manager = RedirectManager::createWithRule($rule);

--- a/tests/cases/RedirectManagerTest.php
+++ b/tests/cases/RedirectManagerTest.php
@@ -452,6 +452,8 @@ class RedirectManagerTest extends \Winter\Redirect\Tests\RedirectPluginTestCase
             'to_date' => Carbon::today()->addWeek(),
         ]);
 
+        self::assertTrue($redirect->save());
+
         $rule = RedirectRule::createWithModel($redirect);
         $manager = RedirectManager::createWithRule($rule);
 
@@ -863,6 +865,8 @@ class RedirectManagerTest extends \Winter\Redirect\Tests\RedirectPluginTestCase
             'from_date' => null,
             'to_date' => null,
         ]);
+
+        self::assertTrue($redirect->save());
 
         $rule = RedirectRule::createWithModel($redirect);
         $manager = RedirectManager::createWithRule($rule);


### PR DESCRIPTION
if a regex rule contains named groups, groups will get matched to cms page params.

e.g.
```
source path: #/path/(?<slug>.*)#
```
The above named group (slug) will match a ":slug" param in a CMS page url.