### PR TITLE
Fix clients relation conflict

### DIFF
--- a/models/Redirect.php
+++ b/models/Redirect.php
@@ -209,11 +209,6 @@ final class Redirect extends Model
         return $this->attributes['match_type'] === self::TYPE_REGEX;
     }
 
-    public function clients(): HasMany
-    {
-        return $this->hasMany(Client::class);
-    }
-
     public function setSortableOrder($itemIds, array $itemOrders = null): void
     {
         $itemIds = array_map(static function ($itemId) {


### PR DESCRIPTION
Due to the new relation conflict detection (https://github.com/wintercms/storm/blob/4a62533dbdce32748e8538e5d442dee5a400c1db/src/Database/Concerns/HasRelationships.php#L372), this PR fixes the error:

```
"Relation "clients" in model "Winter\Redirect\Models\Redirect" is defined both as a relation method and in the relation properties config." on line 378 of /var/www/html/vendor/winter/storm/src/Database/Concerns/HasRelationships.php
```